### PR TITLE
Fix README notebook metadata

### DIFF
--- a/README.ipynb
+++ b/README.ipynb
@@ -2,7 +2,6 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "501eef0d",
    "metadata": {},
    "source": [
     "![Ivy logo](./media/logo.png)\n",
@@ -117,6 +116,23 @@
    "cell_metadata_filter": "-all",
    "main_language": "python",
    "notebook_metadata_filter": "-all"
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.10"
   }
  },
  "nbformat": 4,

--- a/environment.yaml
+++ b/environment.yaml
@@ -28,4 +28,4 @@ dependencies:
   - imageio
   - tqdm
   - jupytext
-  - pre-install
+  - pre-commit


### PR DESCRIPTION
This PR adds back the kernel metadata tp the README notebook, so the user isn't prompted for a kernel when starting it.

Also fixed an error in a package name in the conda environment file.