### PR TITLE
Add code and toggle solution visibility in Landlab grids notebook

### DIFF
--- a/lessons/landlab/landlab/Landlab_grids.ipynb
+++ b/lessons/landlab/landlab/Landlab_grids.ipynb
@@ -966,7 +966,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# import the linear diffuser component here\n"
+    "from landlab.components import LinearDiffuser"
    ]
   },
   {
@@ -982,7 +982,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# check out input variable names\n"
+    "# check out input variable names\n",
+    "LinearDiffuser.input_var_names"
    ]
   },
   {
@@ -1000,7 +1001,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# ask for info related to the input variable 'topographic__elevation'\n"
+    "# ask for info related to the input variable 'topographic__elevation'\n",
+    "LinearDiffuser.var_help(\"topographic__elevation\")"
    ]
   },
   {
@@ -1013,10 +1015,13 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
-    "# recall the question mark notation used to access documentation in Landlab\n"
+    "# recall the question mark notation used to access documentation in Landlab\n",
+    "?LinearDiffuser"
    ]
   },
   {
@@ -1048,6 +1053,22 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "<details>\n",
+    "    <summary><span style=\"color: beige; font-weight: bold;\">Click for a solution</span></summary>\n",
+    "\n",
+    "```python\n",
+    "\n",
+    "# create a new grid here\n",
+    "new_grid = RasterModelGrid((25, 25), 10)\n",
+    "```\n",
+    "\n",
+    "</details>\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "Great, we now have a grid on which we can implement our diffusion component. Recall, however, our diffusion equation from above:\n",
     "\n",
     "$$\\frac{\\partial z}{\\partial t} = D \\nabla^2 z$$.\n",
@@ -1068,6 +1089,23 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<details>\n",
+    "    <summary><span style=\"color: beige; font-weight: bold;\">Click for a solution</span></summary>\n",
+    "\n",
+    "```python\n",
+    "\n",
+    "# add a field of zeros called \"topographic__elevation\" and attach it to the grid nodes\n",
+    "# save the field to an array with a new name\n",
+    "new_elev = new_grid.add_zeros(\"topographic__elevation\", at=\"node\")\n",
+    "```\n",
+    "\n",
+    "</details>\n"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -1077,12 +1115,29 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<details>\n",
+    "    <summary><span style=\"color: beige; font-weight: bold;\">Click for a solution</span></summary>\n",
+    "\n",
+    "```python\n",
+    "\n",
+    "# now elevate the upper half of the landscape, following the `node_of_y` method used in part (d)\n",
+    "new_elev[new_grid.y_of_node > 120] += 10\n",
+    "```\n",
+    "\n",
+    "</details>\n"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "# now display the landscape\n"
+    "# now display the landscape\n",
+    "imshow_grid(new_grid, \"topographic__elevation\")"
    ]
   },
   {
@@ -1098,7 +1153,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# close left and right boundaries\n"
+    "# close left and right boundaries\n",
+    "new_grid.set_closed_boundaries_at_grid_edges(True, False, True, False)"
    ]
   },
   {
@@ -1114,7 +1170,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# instantiate the linear diffuser component here\n"
+    "# instantiate the linear diffuser component here\n",
+    "diffusion_model = LinearDiffuser(new_grid)"
    ]
   },
   {
@@ -1138,6 +1195,24 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "<details>\n",
+    "    <summary><span style=\"color: beige; font-weight: bold;\">Click for a solution</span></summary>\n",
+    "\n",
+    "```python\n",
+    "\n",
+    "# create your for loop here\n",
+    "# hint: you only need two lines of code in this cell to run the model\n",
+    "for _ in range(25):\n",
+    "    diffusion_model.run_one_step(dt)\n",
+    "```\n",
+    "\n",
+    "</details>\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "Great, now visualize your landscape to see if it looks similar to the 5-line model you created in part <b>(d) (Sediment diffusion)."
    ]
   },
@@ -1147,7 +1222,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# visualize landscape here\n"
+    "# visualize landscape\n",
+    "imshow_grid(new_grid, \"topographic__elevation\")"
    ]
   },
   {
@@ -1162,10 +1238,13 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
-    "# check out the optional variables\n"
+    "# check out the optional variables\n",
+    "?LinearDiffuser"
    ]
   },
   {

--- a/lessons/landlab/landlab/Landlab_grids.ipynb
+++ b/lessons/landlab/landlab/Landlab_grids.ipynb
@@ -99,7 +99,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "# get info on RasterModelGrid\n",
@@ -130,7 +132,7 @@
    "outputs": [],
    "source": [
     "# visualize nodes\n",
-    "plot_graph(rmg, at = 'node')"
+    "plot_graph(rmg, at=\"node\")"
    ]
   },
   {
@@ -146,7 +148,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# plot links here"
+    "# visualize links"
    ]
   },
   {
@@ -155,7 +157,26 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# plot cells here"
+    "# visualize cells"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<details>\n",
+    "    <summary><span style=\"color: beige; font-weight: bold;\">Click for a solution</span></summary>\n",
+    "\n",
+    "```python\n",
+    "\n",
+    "# visualize links\n",
+    "plot_graph(rmg, at=\"link\")\n",
+    "\n",
+    "# visualize cells\n",
+    "plot_graph(rmg, at=\"cell\")\n",
+    "```\n",
+    "    \n",
+    "</details>"
    ]
   },
   {
@@ -172,12 +193,42 @@
    "outputs": [],
    "source": [
     "# create hexagonal grid\n",
-    "hmg = HexModelGrid((3, 4), 10)\n",
-    "\n",
+    "hmg = HexModelGrid((3, 4), 10)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# plot nodes\n",
     "\n",
     "# plot links\n",
-    "# plot cells"
+    "\n",
+    "# plot cells\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<details>\n",
+    "    <summary><span style=\"color: beige; font-weight: bold;\">Click for a solution</span></summary>\n",
+    "\n",
+    "```python\n",
+    "\n",
+    "# plot nodes\n",
+    "plot_graph(hmg, at=\"node\")\n",
+    "\n",
+    "# plot links\n",
+    "plot_graph(hmg, at=\"link\")\n",
+    "\n",
+    "# plot cells\n",
+    "plot_graph(hmg, at=\"cell, face\")\n",
+    "```\n",
+    "    \n",
+    "</details>"
    ]
   },
   {
@@ -210,7 +261,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# find number of core nodes here\n"
+    "# find number of core nodes here\n",
+    "rmg.number_of_core_nodes"
    ]
   },
   {
@@ -226,7 +278,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# get index of core nodes"
+    "# get index values of core nodes\n",
+    "rmg.core_nodes"
    ]
   },
   {
@@ -247,7 +300,7 @@
    "outputs": [],
    "source": [
     "# create elevation field filled with zeros\n",
-    "z = rmg.add_zeros('topographic__elevation', at = 'node')"
+    "z = rmg.add_zeros(\"topographic__elevation\", at=\"node\", clobber=True)"
    ]
   },
   {
@@ -264,9 +317,17 @@
    "outputs": [],
    "source": [
     "# print the data type of \"z\"\n",
-    "\n",
-    "\n",
-    "# print the length of \"z\"\n"
+    "type(z)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# print the length of \"z\"\n",
+    "len(z)"
    ]
   },
   {
@@ -283,12 +344,32 @@
    "outputs": [],
    "source": [
     "# set elevation of first core node\n",
-    "z[5] = 5.0\n",
     "\n",
     "# set elevation for next core node\n",
     "\n",
-    "\n",
     "# print array\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<details>\n",
+    "    <summary><span style=\"color: beige; font-weight: bold;\">Click for a solution</span></summary>\n",
+    "\n",
+    "```python\n",
+    "\n",
+    "# set elevation of first core node\n",
+    "z[rmg.core_nodes[0]] = 5.0\n",
+    "\n",
+    "# set elevation for next core node\n",
+    "z[rmg.core_nodes[1]] = 3.6\n",
+    "\n",
+    "# print array\n",
+    "print(z)\n",
+    "```\n",
+    "\n",
+    "</details>"
    ]
   },
   {
@@ -305,7 +386,7 @@
    "outputs": [],
    "source": [
     "# visualize topographic elevation field\n",
-    "imshow_grid(rmg, 'topographic__elevation')"
+    "imshow_grid(rmg, \"topographic__elevation\")"
    ]
   },
   {
@@ -321,7 +402,24 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# add soil depth field here\n"
+    "# add soil depth field here\n",
+    "rmg.add_zeros(\"soil__depth\", at=\"node\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<details>\n",
+    "    <summary><span style=\"color: beige; font-weight: bold;\">Click for a solution</span></summary>\n",
+    "\n",
+    "```python\n",
+    "\n",
+    "# add soil depth field here\n",
+    "rmg.add_zeros(\"soil__depth\", at=\"node\")\n",
+    "```\n",
+    "\n",
+    "</details>\n"
    ]
   },
   {
@@ -408,7 +506,7 @@
     "    0 ----> 0 ----> 0 ----> 0\n",
     "    \n",
     "\n",
-    "Let's plot the layout of the links of our grid object again:"
+    "Let's plot the layout of the nodes and links of our grid object again:"
    ]
   },
   {
@@ -417,8 +515,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# check out the links\n",
-    "plot_graph(rmg, at = 'link')"
+    "# check out the nodes and links\n",
+    "plot_graph(rmg, at=\"node, link\")"
    ]
   },
   {
@@ -437,7 +535,8 @@
     "# create a gradient array\n",
     "dzdx = rmg.calc_grad_at_link(z)\n",
     "\n",
-    "# print it out\n"
+    "# print it out\n",
+    "print(dzdx)"
    ]
   },
   {
@@ -530,6 +629,22 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "<details>\n",
+    "    <summary><span style=\"color: beige; font-weight: bold;\">Click for a solution</span></summary>\n",
+    "\n",
+    "```python\n",
+    "\n",
+    "# get all of the values of vertical links\n",
+    "dzdx[rmg.vertical_links]\n",
+    "```\n",
+    "\n",
+    "</details>\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### (d) Sediment diffusion\n",
     "\n",
     "Finally, we can put together the basics of Landlab with some geomorphic soil transport laws to write a quick-n-easy diffusion model! First, we'll need to tackle a tiny bit of math.\n",
@@ -571,6 +686,22 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "<details>\n",
+    "    <summary><span style=\"color: beige; font-weight: bold;\">Click for a solution</span></summary>\n",
+    "\n",
+    "```python\n",
+    "\n",
+    "# create your grid here\n",
+    "mg = RasterModelGrid((25, 25), 10)\n",
+    "```\n",
+    "\n",
+    "</details>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "We need to define our hillslope diffusivity, `D`, and choose a timestep. For the timestep we use a [Courant–Friedrichs–Lewy condition](https://en.wikipedia.org/wiki/Courant–Friedrichs–Lewy_condition) of $C_{cfl}=0.2$. This will keep our solution numerically stable. \n",
     "\n",
     "$C_{cfl} = \\frac{\\Delta t D}{\\Delta x^2} = 0.2$\n",
@@ -588,7 +719,7 @@
     "D = 0.01\n",
     "\n",
     "# calculate timestep\n",
-    "dt = 0.2 * mg.dx * mg.dx / D\n",
+    "dt = 0.2 * mg.dx**2 / D\n",
     "\n",
     "# print timestep\n",
     "print(dt)"
@@ -608,6 +739,22 @@
    "outputs": [],
    "source": [
     "# create elevation field here\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<details>\n",
+    "    <summary><span style=\"color: beige; font-weight: bold;\">Click for a solution</span></summary>\n",
+    "\n",
+    "```python\n",
+    "\n",
+    "# create elevation field here\n",
+    "elev = mg.add_zeros(\"topographic__elevation\", at=\"node\")\n",
+    "```\n",
+    "\n",
+    "</details>"
    ]
   },
   {
@@ -649,6 +796,22 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "<details>\n",
+    "    <summary><span style=\"color: beige; font-weight: bold;\">Click for a solution</span></summary>\n",
+    "\n",
+    "```python\n",
+    "\n",
+    "# display landscape\n",
+    "imshow_grid(mg, \"topographic__elevation\")\n",
+    "```\n",
+    "\n",
+    "</details>\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "Now we need to create a field that can track our sediment flux between nodes. Since this is a value that exists <i>between nodes</i>, it will be stored on <i>links</i>. Create a field called `sediment__flux` that is associated with grid `link`s, and save it to an array called `qs`."
    ]
   },
@@ -659,6 +822,22 @@
    "outputs": [],
    "source": [
     "# create sediment flux field here\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<details>\n",
+    "    <summary><span style=\"color: beige; font-weight: bold;\">Click for a solution</span></summary>\n",
+    "\n",
+    "```python\n",
+    "\n",
+    "# create sediment flux field here\n",
+    "qs = mg.add_zeros(\"sediment__flux\", at=\"link\")\n",
+    "```\n",
+    "\n",
+    "</details>\n"
    ]
   },
   {
@@ -681,7 +860,23 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Finally, we want to evolve our landscape for 50000 years. Since our timestep is 2000 years, this means we'll run a for-loop for 25 iterations. The steps are as follows:\n",
+    "<details>\n",
+    "    <summary><span style=\"color: beige; font-weight: bold;\">Click for a solution</span></summary>\n",
+    "\n",
+    "```python\n",
+    "\n",
+    "# close left and right boundaries\n",
+    "mg.set_closed_boundaries_at_grid_edges(True, False, True, False)\n",
+    "```\n",
+    "\n",
+    "</details>\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Finally, we want to evolve our landscape for 50000 years. Since our timestep is 2000 years, this means we'll run a for loop for 25 iterations. The steps are as follows:\n",
     "\n",
     "- calculate a topographic gradient\n",
     "- multiply that gradient by the hillslope diffusivity\n",
@@ -696,7 +891,27 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# write for loop to elove landscape\n"
+    "# write for loop to evolve landscape\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<details>\n",
+    "    <summary><span style=\"color: beige; font-weight: bold;\">Click for a solution</span></summary>\n",
+    "\n",
+    "```python\n",
+    "\n",
+    "# write for loop to evolve landscape\n",
+    "for i in range(25):\n",
+    "    g = mg.calc_grad_at_link(elev)\n",
+    "    qs[mg.active_links] = -D * g[mg.active_links]\n",
+    "    dzdt = -mg.calc_flux_div_at_node(qs)\n",
+    "    elev[mg.core_nodes] += dzdt[mg.core_nodes] * dt\n",
+    "```\n",
+    "\n",
+    "</details>\n"
    ]
   },
   {
@@ -712,7 +927,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# display your final landscape\n"
+    "# display your final landscape\n",
+    "imshow_grid(mg, \"topographic__elevation\")"
    ]
   },
   {
@@ -976,9 +1192,9 @@
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "CSDMS",
    "language": "python",
-   "name": "python3"
+   "name": "csdms"
   },
   "language_info": {
    "codemirror_mode": {
@@ -990,9 +1206,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.4"
+   "version": "3.9.12"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
This PR modifies the Landlab grids notebook by
1. adding code to previously empty cells,
2. adding toggle-able solutions to some questions, and
3. making minor edits to code and prose.

I'm hoping these changes will help others (like me) teach with this notebook, while not violating the spirit of the original notebook by giving away answers to all of the questions.

This fixes #82.