### PR TITLE
Use EarthscapeHub name

### DIFF
--- a/README.ipynb
+++ b/README.ipynb
@@ -2,6 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "72d65efa",
    "metadata": {},
    "source": [
     "![Ivy logo](./media/logo.png)\n",
@@ -9,7 +10,7 @@
     "<!-- Links -->\n",
     "\n",
     "[jhub]: https://csdms.colorado.edu/wiki/JupyterHub\n",
-    "[badge]: https://img.shields.io/badge/OpenEarthscape-JupyterHub-orange\n",
+    "[badge]: https://img.shields.io/badge/Run%20on-EarthscapeHub-orange\n",
     "[jupyter]: ./lessons/jupyter/index.md\n",
     "[shell]: ./lessons/shell/index.md\n",
     "[editors]: ./lessons/editors/index.md\n",
@@ -66,14 +67,14 @@
     "The lessons can be run locally\n",
     "if a user installs Anaconda and a `git` client on their computer.\n",
     "All lessons are also available to run\n",
-    "on the [OpenEarthscape JupyterHub][jhub].\n",
+    "on [EarthscapeHub][jhub].\n",
     "Click this button:\n",
     "\n",
-    "[![Run on OpenEarthscape JupyterHub][badge]][jhub-link]\n",
+    "[![Run on EarthscapeHub][badge]][jhub-link]\n",
     "\n",
-    "to open the lessons directly on the OpenEarthscape JupyterHub!\n",
+    "to open the lessons directly on the EarthscapeHub *lab* instance!\n",
     "\n",
-    "> **Note:** The OpenEarthscape JupyterHub is password-protected.\n",
+    "> **Note:** The EarthscapeHub *lab* instance is password-protected.\n",
     "  Please contact your instructor about obtaining a login,\n",
     "  or visit [this][jhub-info] CSDMS wiki page for more information.\n",
     "\n",
@@ -123,23 +124,6 @@
    "cell_metadata_filter": "-all",
    "main_language": "python",
    "notebook_metadata_filter": "-all"
-  },
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.6.10"
   }
  },
  "nbformat": 4,

--- a/README.ipynb
+++ b/README.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "72d65efa",
+   "id": "b56d3d13",
    "metadata": {},
    "source": [
     "![Ivy logo](./media/logo.png)\n",
@@ -96,13 +96,7 @@
     "Cybertraining for Earth Surface Processes Modelers*\n",
     "(award numbers\n",
     "[1924259](https://www.nsf.gov/awardsearch/showAward?AWD_ID=1924259) and\n",
-    "[1924185](https://www.nsf.gov/awardsearch/showAward?AWD_ID=1924185)),\n",
-    "led by [Irina Overeem](https://www.colorado.edu/geologicalsciences/irina-overeem)\n",
-    "with a project team of\n",
-    "[Leilani Arthurs](https://www.colorado.edu/geologicalsciences/leilani-arthurs),\n",
-    "[Benjamin Campforts](https://instaar.colorado.edu/people/benjamin-campforts/),\n",
-    "[Nicole Gasparini](https://sse.tulane.edu/eens/faculty/gasparini), and\n",
-    "[Mark Piper](https://instaar.colorado.edu/people/mark-piper/).\n",
+    "[1924185](https://www.nsf.gov/awardsearch/showAward?AWD_ID=1924185)).\n",
     "\n",
     "Portions of the CSDMS Ivy shell and Python lessons are derived\n",
     "from material that is copyright\n",

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <!-- Links -->
 
 [jhub]: https://csdms.colorado.edu/wiki/JupyterHub
-[badge]: https://img.shields.io/badge/OpenEarthscape-JupyterHub-orange
+[badge]: https://img.shields.io/badge/Run%20on-EarthscapeHub-orange
 [jupyter]: ./lessons/jupyter/index.md
 [shell]: ./lessons/shell/index.md
 [editors]: ./lessons/editors/index.md
@@ -60,14 +60,14 @@ although the ordering below represents a typical progression.
 The lessons can be run locally
 if a user installs Anaconda and a `git` client on their computer.
 All lessons are also available to run
-on the [OpenEarthscape JupyterHub][jhub].
+on [EarthscapeHub][jhub].
 Click this button:
 
-[![Run on OpenEarthscape JupyterHub][badge]][jhub-link]
+[![Run on EarthscapeHub][badge]][jhub-link]
 
-to open the lessons directly on the OpenEarthscape JupyterHub!
+to open the lessons directly on the EarthscapeHub *lab* instance!
 
-> **Note:** The OpenEarthscape JupyterHub is password-protected.
+> **Note:** The EarthscapeHub *lab* instance is password-protected.
   Please contact your instructor about obtaining a login,
   or visit [this][jhub-info] CSDMS wiki page for more information.
 

--- a/README.md
+++ b/README.md
@@ -89,13 +89,7 @@ CSDMS Ivy grew from a National Science Foundation Cybertraining pilot program,
 Cybertraining for Earth Surface Processes Modelers*
 (award numbers
 [1924259](https://www.nsf.gov/awardsearch/showAward?AWD_ID=1924259) and
-[1924185](https://www.nsf.gov/awardsearch/showAward?AWD_ID=1924185)),
-led by [Irina Overeem](https://www.colorado.edu/geologicalsciences/irina-overeem)
-with a project team of
-[Leilani Arthurs](https://www.colorado.edu/geologicalsciences/leilani-arthurs),
-[Benjamin Campforts](https://instaar.colorado.edu/people/benjamin-campforts/),
-[Nicole Gasparini](https://sse.tulane.edu/eens/faculty/gasparini), and
-[Mark Piper](https://instaar.colorado.edu/people/mark-piper/).
+[1924185](https://www.nsf.gov/awardsearch/showAward?AWD_ID=1924185)).
 
 Portions of the CSDMS Ivy shell and Python lessons are derived
 from material that is copyright

--- a/lessons/bmi/index.ipynb
+++ b/lessons/bmi/index.ipynb
@@ -17,6 +17,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -40,7 +41,7 @@
     "$ pip install -e .\n",
     "```\n",
     "\n",
-    "The example has already been installed on the OpenEarthscape JupyterHub.\n"
+    "The example has already been installed on EarthscapeHub.\n"
    ]
   },
   {

--- a/lessons/conda/index.md
+++ b/lessons/conda/index.md
@@ -22,7 +22,7 @@ packages from a Python installation.
 `conda` ensures that the packages work together without conflict.
 
 Because much of our work with Ivy takes place
-on the [OpenEarthscape JupyterHub](https://csdms.colorado.edu/wiki/JupyterHub),
+on [EarthscapeHub](https://csdms.colorado.edu/wiki/JupyterHub),
 we don't spend much time on `conda` here;
 however,
 we recommend installing Anaconda on your computer

--- a/lessons/jupyter/index.md
+++ b/lessons/jupyter/index.md
@@ -27,11 +27,11 @@ CSDMS provides a [JupyterHub][jhub]
 where Ivy course material can be viewed and run.
 Click this button:
 
-[![Run on OpenEarthscape JupyterHub][badge]][jhub-link]
+[![Run on EarthscapeHub][badge]][jhub-link]
 
-to open the CSDMS Ivy lessons directly on the OpenEarthscape JupyterHub!
+to open the lessons directly on the EarthscapeHub *lab* instance!
 
-> **Note:** The OpenEarthscape JupyterHub is password-protected.
+> **Note:** The EarthscapeHub *lab* instance is password-protected.
   Please contact your instructor about obtaining a login,
   or visit [this][jhub-info] CSDMS wiki page for more information.
 
@@ -50,7 +50,7 @@ Like JupyterHub, JupyterLab can be installed
 in the cloud, on a server, or locally.
 
 Take a few minutes to familiarize yourself with the JupyterLab interface
-on the OpenEarthscape Jupyterhub.
+on EarthscapeHub.
 
 ## Jupyter Notebook
 
@@ -88,7 +88,7 @@ The majority of the CSDMS Ivy course material is built as notebooks.
 
 <!-- Links, by alpha -->
 
-[badge]: https://img.shields.io/badge/OpenEarthscape-JupyterHub-orange
+[badge]: https://img.shields.io/badge/Run%20on-EarthscapeHub-orange
 [jhub]: https://lab.openearthscape.org
 [jhub-link]: https://lab.openearthscape.org/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2Fcsdms%2Fivy&urlpath=lab%2Ftree%2Fivy%2FREADME.ipynb%3Fautodecode&branch=main
 [jhub-info]: https://csdms.colorado.edu/wiki/JupyterHub

--- a/lessons/shell/index.md
+++ b/lessons/shell/index.md
@@ -88,7 +88,7 @@ we provide a shorter lesson in which we provide only the most relevant informati
 
 1. [The shell, in brief](./short-shell.md)
 
-This shortened lesson is designed to run on the OpenEarthscape JupyterHub.
+This shortened lesson is designed to run on [EarthscapeHub](https://csdms.colorado.edu/wiki/JupyterHub).
 
 ## Resources
 

--- a/lessons/shell/short-shell.md
+++ b/lessons/shell/short-shell.md
@@ -3,7 +3,7 @@
 # The shell, in brief
 
 This shortened introduction to the shell
-is designed to run on the OpenEarthscape JupyterHub.
+is designed to run on [EarthscapeHub][jhub]
 
 ## Files and directories
 
@@ -202,7 +202,6 @@ $ head readme.md
 <!-- Links -->
 
 [jhub]: https://csdms.colorado.edu/wiki/JupyterHub
-[badge]: https://img.shields.io/badge/OpenEarthscape-JupyterHub-orange
 [jupyter]: ./lessons/jupyter/index.md
 [shell]: ./lessons/shell/index.md
 [editors]: ./lessons/editors/index.md


### PR DESCRIPTION
This PR swaps "OpenEarthscape JupyterHub" for the initially intended "EarthscapeHub" name. It includes an updated badge button.