### PR TITLE
De-link old shell lessons

### DIFF
--- a/README.ipynb
+++ b/README.ipynb
@@ -1,6 +1,7 @@
 {
  "cells": [
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "b56d3d13",
    "metadata": {},
@@ -98,7 +99,7 @@
     "[1924259](https://www.nsf.gov/awardsearch/showAward?AWD_ID=1924259) and\n",
     "[1924185](https://www.nsf.gov/awardsearch/showAward?AWD_ID=1924185)).\n",
     "\n",
-    "Portions of the CSDMS Ivy shell and Python lessons are derived\n",
+    "Portions of the CSDMS Ivy Python lessons are derived\n",
     "from material that is copyright\n",
     "[Software Carpentry][swc]\n",
     "and remixed under their [license][swc-license].\n",

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Cybertraining for Earth Surface Processes Modelers*
 [1924259](https://www.nsf.gov/awardsearch/showAward?AWD_ID=1924259) and
 [1924185](https://www.nsf.gov/awardsearch/showAward?AWD_ID=1924185)).
 
-Portions of the CSDMS Ivy shell and Python lessons are derived
+Portions of the CSDMS Ivy Python lessons are derived
 from material that is copyright
 [Software Carpentry][swc]
 and remixed under their [license][swc-license].

--- a/lessons/shell/index.md
+++ b/lessons/shell/index.md
@@ -77,22 +77,13 @@ This process is repeated every time we enter a command.
 
 This lesson on the shell continues in the following sections:
 
-1. [Files and directories](./files-and-directories.md)
-1. [Creating things](./creating-things.md)
-1. [Pipes and filters](./pipes-and-filters.md)
-1. [Finding things](./finding-things.md)
-1. [Getting things from elsewhere](./getting-things.md)
-
-Alternately,
-we provide a shorter lesson in which we provide only the most relevant information:
-
 1. [The shell, in brief](./short-shell.md)
 
-This shortened lesson is designed to run on [EarthscapeHub](https://csdms.colorado.edu/wiki/JupyterHub).
+This lesson is designed to run on [EarthscapeHub](https://csdms.colorado.edu/wiki/JupyterHub).
 
 ## Resources
 
 * [Five reasons why researchers should learn to love the command line](https://www.nature.com/articles/d41586-021-00263-0)
-* This lesson is loosely based on the Software Carpentry [shell lesson](https://swcarpentry.github.io/shell-novice/)
+* The Software Carpentry [shell lesson](https://swcarpentry.github.io/shell-novice/)
 * The [Bash Guide for Beginners](http://www.tldp.org/LDP/Bash-Beginners-Guide/html/) from the Linux Documentation Project
 * The [GNU Bash Manual](https://www.gnu.org/software/bash/manual/) in various formats

--- a/lessons/shell/short-shell.md
+++ b/lessons/shell/short-shell.md
@@ -2,7 +2,7 @@
 
 # The shell, in brief
 
-This shortened introduction to the shell
+This introduction to the shell
 is designed to run on [EarthscapeHub](https://csdms.colorado.edu/wiki/JupyterHub).
 
 ## Files and directories

--- a/lessons/shell/short-shell.md
+++ b/lessons/shell/short-shell.md
@@ -3,7 +3,7 @@
 # The shell, in brief
 
 This shortened introduction to the shell
-is designed to run on [EarthscapeHub][jhub]
+is designed to run on [EarthscapeHub](https://csdms.colorado.edu/wiki/JupyterHub).
 
 ## Files and directories
 


### PR DESCRIPTION
This PR unlinks (but does not delete) the old shell lessons derived from Software Carpentry from the shell lesson index page.