### PR TITLE
Test notebooks once on internal PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,6 +38,11 @@ jobs:
         run: nox -s test
 
   test-notebooks:
+
+    if:
+      github.event_name == 'push' ||
+      github.event.pull_request.head.repo.full_name != github.repository
+
     name: Test the notebooks
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This PR adds a conditional to the test workflow so that the notebooks are not tested twice on each push for an internal PR.