### PR TITLE
Skip testing notebook with external data

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -16,6 +16,7 @@ addopts =
   --ignore-glob=*/bedrockLandslides_on_DEMs.ipynb
   --ignore-glob=*/ku-eml-paleomip.ipynb
   --ignore-glob=*/paleomip-processing.ipynb
+  --ignore-glob=*/PFdepth-dependent-diffusion.ipynb
   --ignore-glob=*/create_a_component.ipynb
   --ignore-glob=*/landlab-fault-scarp-for-espin.ipynb
   --ignore-glob=*/intro-to-grids.ipynb


### PR DESCRIPTION
There's a notebook that uses external data (that lives in the `/data` directory of the _lab_ Hub), causing it to fail in the CI workflow. I added it to the ignore list for testing.