### PR TITLE
Fix typos in OOP lesson

### DIFF
--- a/lessons/python/7_oop.ipynb
+++ b/lessons/python/7_oop.ipynb
@@ -36,10 +36,10 @@
     "In this lesson,\n",
     "we'll go over some of the basics of OOP using Python.\n",
     "This will be useful for EPSP scientists because\n",
-    "numerical models written with OOP techinques tend to be easier understand, debug, maintain, and extend.\n",
+    "numerical models written with OOP techniques tend to be easier understand, debug, maintain, and extend.\n",
     "Landlab is an example.\n",
-    "Further, if you intens to develop a Landlab component,\n",
-    "it has to be written with OOP techinues."
+    "Further, if you intend to develop a Landlab component,\n",
+    "it must be written with OOP techniques."
    ]
   },
   {
@@ -227,7 +227,7 @@
     "In the signatures of the two methods,\n",
     "we're using [type hints](https://docs.python.org/3/library/typing.html).\n",
     "This is a choice;\n",
-    "they're useful, but not necessaery.\n",
+    "they're useful, but not necessary.\n",
     "\n",
     "Within a class definition,\n",
     "the variable *self* is used to define and access attributes and methods.\n",
@@ -410,7 +410,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Note that most of the work in the contructor goes into forming arguments appropriate for `Shape`,\n",
+    "Note that most of the work in the constructor goes into forming arguments appropriate for `Shape`,\n",
     "although creating *w* and *h* attributes for `Rectangle` helps with calculating the area."
    ]
   },
@@ -620,7 +620,7 @@
    "source": [
     "It requires time to become adept at object-oriented programming,\n",
     "but the time is usually well-spent\n",
-    "bcause code (think model code!) that is developed with OOP techniques\n",
+    "because code (think model code!) that is developed with OOP techniques\n",
     "tends to be more robust and easier to test, maintain, and extend.\n",
     "\n",
     "The concepts from this lesson are explored further in a recent CSDMS [webinar](https://youtu.be/dLrahDArm4w)\n",
@@ -642,7 +642,7 @@
     "| class       | the programming structure that defines what goes into an object |\n",
     "| attribute   | data associated with an object |\n",
     "| method      | a function that belongs to an object |\n",
-    "| instance    | synoym for object |\n",
+    "| instance    | synonym for object |\n",
     "| constructor | the function called when an object is created |\n",
     "| inheritance | the mechanism for deriving a new class from an existing class|\n",
     "| subclass    | a class derived through inheritance |\n",

--- a/lessons/python/7_oop.ipynb
+++ b/lessons/python/7_oop.ipynb
@@ -125,9 +125,10 @@
     "tags": []
    },
    "source": [
-    "![Shapes UML diagram](./media/shapes-uml-diagram.png \"UML class diagrams for Shape, Circle, Rectangle, and Square.\")\n",
-    "\n",
-    "*Figure 2: Class diagrams for Shape, Circle, Rectangle, and Square.*"
+    "<figure>\n",
+    "    <img src=\"https://raw.githubusercontent.com/csdms/ivy/main/lessons/python/media/shapes-uml-diagram.png\" alt=\"UML class diagrams for Shape, Circle, Rectangle, and Square.\"/>\n",
+    "    <figcaption><i>Figure 2: Class diagrams for Shape, Circle, Rectangle, and Square.</i></figcaption>\n",
+    "</figure>"
    ]
   },
   {


### PR DESCRIPTION
This PR fixes several typos and spelling errors in the new OOP lesson. I also used an HTML `<figure>` instead of Markdown for Figure 2 to give the two figures in the lesson a consistent look.

Thank you @archanaprasad11 for reviewing the lesson!