### PR TITLE
Use a static matplotlib backend in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,4 +58,6 @@ jobs:
         run: pip install nox
 
       - name: Test
+        env:
+          MPLBACKEND: "Agg"
         run: nox -s test-notebooks

--- a/lessons/python/visualization.ipynb
+++ b/lessons/python/visualization.ipynb
@@ -320,7 +320,7 @@
     "axes3.set_xlabel(\"<--N   S -->\")\n",
     "axes3.set_title(\"East\")\n",
     "\n",
-    "plt.show(fig)"
+    "plt.show()"
    ]
   },
   {

--- a/lessons/requirements.in
+++ b/lessons/requirements.in
@@ -3,7 +3,7 @@ bmi-topography
 bmipy
 imageio
 landlab >=2.5
-matplotlib <3.7.2
+matplotlib
 notebook
 numpy
 pandas


### PR DESCRIPTION
This PR updates Ivy for matplotlib 3.7.2, which was causing a failure in the CI. The fix applied here--setting a static backend for matplotlib in the CI--follows https://github.com/landlab/landlab/pull/1714.

This fixes #113.