### PR TITLE
Switch from Mambaforge to Miniforge

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,9 +46,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+
+      - uses: conda-incubator/setup-miniconda@v3
         with:
-          python-version: 3.11
+          python-version: "3.11"
+          miniforge-version: latest
 
       - name: Install nox
         run: pip install nox

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,11 +46,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
-      - uses: conda-incubator/setup-miniconda@v3
+      - uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
-          miniforge-version: latest
+          python-version: 3.11
 
       - name: Install nox
         run: pip install nox

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,6 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v3
         with:
           python-version: "${{ matrix.python-version }}"
-          miniforge-variant: Mambaforge
           miniforge-version: latest
 
       - name: Install nox
@@ -51,7 +50,6 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v3
         with:
           python-version: "3.11"
-          miniforge-variant: Mambaforge
           miniforge-version: latest
 
       - name: Install nox

--- a/noxfile.py
+++ b/noxfile.py
@@ -30,7 +30,7 @@ def test(session: nox.Session) -> None:
     session.run("pytest", *args)
 
 
-@nox.session(name="test-notebooks", venv_backend="mamba", python="3.11")
+@nox.session(name="test-notebooks", venv_backend="conda", python="3.11")
 def test_notebooks(session: nox.Session) -> None:
     """Run the notebooks."""
     args = [


### PR DESCRIPTION
Mambaforge is [going away](https://conda-forge.org/news/2024/07/29/sunsetting-mambaforge/) in favor of Miniforge. This PR switches over the CI testing workflow.