### PR TITLE
Remove python 3.9 and 3.10 from testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.11", "3.12"]
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
I've removed Python 3.9 and 3.10 from the tests. We now test with Python 3.11 and 3.12.