### PR TITLE
Remove the $ prompt from the ivy GitHub lessons

### DIFF
--- a/lessons/git/configuring-git.md
+++ b/lessons/git/configuring-git.md
@@ -10,13 +10,13 @@ Git Bash on Windows).
 
 Make sure `git` is installed and in the application search path:
 ```
-$ git --version
+git --version
 ```
 
 Configure `git` on your machine with the following commands:
 ```
-$ git config --global user.name "YOUR NAME"
-$ git config --global user.email "YOUR EMAIL"
+git config --global user.name "YOUR NAME"
+git config --global user.email "YOUR EMAIL"
 ```
 Substitute your name and email address above,
 keeping the quote marks.
@@ -28,7 +28,7 @@ please [sign up](https://github.com/signup) for an account on GitHub.)
 
 You can also set the default editor used with `git`:
 ```
-$ git config --global core.editor "nano -w"
+git config --global core.editor "nano -w"
 ```
 We'll use `nano` by default,
 but if you prefer a different editor (like `vim` or `emacs`),
@@ -36,7 +36,7 @@ this is how it can be set.
 
 Check the configuration you set:
 ```
-$ git config --list
+git config --list
 ```
 
 
@@ -55,7 +55,7 @@ We'll see other software (e.g., `conda`) that uses a similar subcommand syntax.
 `git` provides several ways to get help.
 Get help on the `git` command itself:
 ```
-$ git --help
+git --help
 ```
 The output from this command shows the most common subcommands.
 Get help on a specific subcommand with:
@@ -68,7 +68,7 @@ on all of the options for the `config` subcommand.
 
 To see a list of all subcommands, try:
 ```
-$ git --help -a
+git --help -a
 ```
 
 `git` also has a (very long) `man` page:

--- a/lessons/git/git-workflow.md
+++ b/lessons/git/git-workflow.md
@@ -98,14 +98,14 @@ copy of the current state of the original.
 
 On your computer, open a terminal and change to your home directory:
 ```
-$ cd
+cd
 ```
 Note that this is a convenience; you can do the following steps anywhere on the filesystem.
 
 Now clone your repository from GitHub.
 The syntax for the `git clone` subcommand is
 ```
-$ git clone [repository-url]
+git clone [repository-url]
 ```
 where the bracketed text should be replaced with the SSH URL of your new repository.
 You'll be prompted to enter the passphrase for your SSH key.
@@ -113,8 +113,8 @@ You'll be prompted to enter the passphrase for your SSH key.
 The repository is cloned into the directory `ivy-collaboration`.
 Change to it and view its contents:
 ```
-$ cd ivy-collaboration
-$ ls
+cd ivy-collaboration
+ls
 CONTRIBUTORS.md LICENSE   README.md
 ```
 
@@ -125,7 +125,7 @@ The next step in the workflow isn't isn't necessary at this point, but it's some
 
 Use the `git status` subcommand to check on the current state of the repository:
 ```
-$ git status
+git status
 On branch main
 Your branch is up to date with 'origin/main'.
 
@@ -166,7 +166,7 @@ let's name this branch `update-contributors`.
 If your GitHub username is `@mdpiper`,
 this would be:
 ```
-$ git branch mdpiper/update-contributors
+git branch mdpiper/update-contributors
 ```
 
 Although we've created a new branch,
@@ -175,7 +175,7 @@ the one accepting changes,
 is still the default `main` branch,
 as we can see with `git branch`:
 ```
-$ git branch
+git branch
 * main
   mdpiper/update-contributors
 ```
@@ -185,7 +185,7 @@ To change the current branch,
 use the `git checkout` subcommand
 (again, for a hypothetical user `@mdpiper`):
 ```
-$ git checkout mdpiper/update-contributors
+git checkout mdpiper/update-contributors
 Switched to branch 'mdpiper/update-contributors
 ```
 You can verify that the new branch is current with `git branch` or `git status`.
@@ -201,7 +201,7 @@ Recall that the `ivy-collaboration` repository
 has a file, `CONTRIBUTORS.md`.
 View the files in the repository:
 ```
-$ ls
+ls
 CONTRIBUTORS.md LICENSE   README.md
 ```
 With your favorite text editor,
@@ -214,7 +214,7 @@ Save the file.
 Now that we've changed a file that's under version control,
 view the changes with `git diff`:
 ```
-$ git diff CONTRIBUTORS.md
+git diff CONTRIBUTORS.md
 diff --git a/CONTRIBUTORS.md b/CONTRIBUTORS.md
 index 23d368e..41f5c9b 100644
 --- a/CONTRIBUTORS.md
@@ -229,7 +229,7 @@ index 23d368e..41f5c9b 100644
 
 Then check on the state of the repository with `git status`:
 ```
-$ git status
+git status
 On branch mdpiper/update-contributors
 Your branch is up-to-date with 'origin/main'.
 Changes not staged for commit:
@@ -250,12 +250,12 @@ At this point, `git` is aware that a file has changed in the repository.
 The next step is to call `git add` on this file
 so that `git` knows that its changes are intended to be included in the repository.
 ```
-$ git add CONTRIBUTORS.md
+git add CONTRIBUTORS.md
 ```
 
 Check the result of this command with `git status`:
 ```
-$ git status
+git status
 On branch mdpiper/update-contributors
 Your branch is up-to-date with 'origin/main'.
 Changes to be committed:
@@ -278,7 +278,7 @@ to stage a subset of related changes to be grouped into a single commit.
 To finalize the changes to the repository,
 we *commit* them with `git commit`:
 ```
-$ git commit -m "Add member to contributor list"
+git commit -m "Add member to contributor list"
 [mdpiper/update-contributors 4c9565b] Add member to contributor list
  1 file changed, 1 insertion(+), 1 deletion(-)
 ```
@@ -290,7 +290,7 @@ describing why the change is being made.
 It's also a convention to use imperative case.
 Check the result with `git status`:
 ```
-$ git status
+git status
 On branch mdpiper/update-contributors
 nothing to commit, working directory clean
 ```
@@ -306,7 +306,7 @@ Our local repository now differs from its remotes.
 
 View the history of revisions to the repository with `git log`:
 ```
-$ git log
+git log
 commit 4c9565be25ca5c91d66867631112c68301250991
 Author: Mark Piper <mark.piper@colorado.edu>
 Date:   Mon Jun 7 15:19:32 2021 -0600
@@ -336,7 +336,7 @@ Note that in order to push changes to a remote,
 you must have write access on the remote.
 Therefore, push the changes with:
 ```
-$ git push origin mdpiper/update-contributors
+git push origin mdpiper/update-contributors
 Counting objects: 3, done.
 Delta compression using up to 16 threads.
 Compressing objects: 100% (3/3), done.
@@ -409,7 +409,7 @@ We can *sync* these repositories in a few steps.
 First,
 use the `git remote` subcommand to view what remotes are being tracked by your local repository:
 ```
-$ git remote -v
+git remote -v
 origin	git@github.com:mdpiper/ivy-collaboration.git (fetch)
 origin	git@github.com:mdpiper/ivy-collaboration.git (push)
 ```
@@ -418,12 +418,12 @@ By default,
 the only remote tracked is *origin*.
 We can track the *upstream* remote, as well, with:
 ```
-$ git remote add upstream git@github.com:csdms/ivy-collaboration.git
+git remote add upstream git@github.com:csdms/ivy-collaboration.git
 ```
 
 Check the result with another call to `git remote`:
 ```
-$ git remote -v
+git remote -v
 origin	git@github.com:mdpiper/ivy-collaboration.git (fetch)
 origin	git@github.com:mdpiper/ivy-collaboration.git (push)
 upstream	git@github.com:csdms/ivy-collaboration.git (fetch)
@@ -433,7 +433,7 @@ upstream	git@github.com:csdms/ivy-collaboration.git (push)
 Next, switch back to the *main* branch in your local repository.
 This is the branch into which the pull request was merged.
 ```
-$ git checkout main
+git checkout main
 Switched to branch 'main'
 Your branch is up-to-date with 'origin/main'.
 ```
@@ -441,14 +441,14 @@ Your branch is up-to-date with 'origin/main'.
 Now *pull* the changes from the *upstream* remote into you local repository
 with the `git pull` subcommand:
 ```
-$ git pull upstream main
+git pull upstream main
 ```
 
 Your local repository is now in sync with the *upstream* remote.
 
 Finally, sync the *origin* remote by pushing the changes from your local repository:
 ```
-$ git push origin main
+git push origin main
 ```
 
 All three repositories,

--- a/lessons/git/git-workflow.md
+++ b/lessons/git/git-workflow.md
@@ -115,6 +115,8 @@ Change to it and view its contents:
 ```
 cd ivy-collaboration
 ls
+```
+```
 CONTRIBUTORS.md LICENSE   README.md
 ```
 
@@ -126,6 +128,8 @@ The next step in the workflow isn't isn't necessary at this point, but it's some
 Use the `git status` subcommand to check on the current state of the repository:
 ```
 git status
+```
+```
 On branch main
 Your branch is up to date with 'origin/main'.
 
@@ -176,6 +180,8 @@ is still the default `main` branch,
 as we can see with `git branch`:
 ```
 git branch
+```
+```
 * main
   mdpiper/update-contributors
 ```
@@ -202,6 +208,8 @@ has a file, `CONTRIBUTORS.md`.
 View the files in the repository:
 ```
 ls
+```
+```
 CONTRIBUTORS.md LICENSE   README.md
 ```
 With your favorite text editor,
@@ -215,6 +223,8 @@ Now that we've changed a file that's under version control,
 view the changes with `git diff`:
 ```
 git diff CONTRIBUTORS.md
+```
+```diff
 diff --git a/CONTRIBUTORS.md b/CONTRIBUTORS.md
 index 23d368e..41f5c9b 100644
 --- a/CONTRIBUTORS.md
@@ -230,6 +240,8 @@ index 23d368e..41f5c9b 100644
 Then check on the state of the repository with `git status`:
 ```
 git status
+```
+```
 On branch mdpiper/update-contributors
 Your branch is up-to-date with 'origin/main'.
 Changes not staged for commit:
@@ -256,6 +268,8 @@ git add CONTRIBUTORS.md
 Check the result of this command with `git status`:
 ```
 git status
+```
+```
 On branch mdpiper/update-contributors
 Your branch is up-to-date with 'origin/main'.
 Changes to be committed:
@@ -279,6 +293,8 @@ To finalize the changes to the repository,
 we *commit* them with `git commit`:
 ```
 git commit -m "Add member to contributor list"
+```
+```
 [mdpiper/update-contributors 4c9565b] Add member to contributor list
  1 file changed, 1 insertion(+), 1 deletion(-)
 ```
@@ -291,6 +307,8 @@ It's also a convention to use imperative case.
 Check the result with `git status`:
 ```
 git status
+```
+```
 On branch mdpiper/update-contributors
 nothing to commit, working directory clean
 ```
@@ -307,6 +325,8 @@ Our local repository now differs from its remotes.
 View the history of revisions to the repository with `git log`:
 ```
 git log
+```
+```
 commit 4c9565be25ca5c91d66867631112c68301250991
 Author: Mark Piper <mark.piper@colorado.edu>
 Date:   Mon Jun 7 15:19:32 2021 -0600
@@ -337,6 +357,8 @@ you must have write access on the remote.
 Therefore, push the changes with:
 ```
 git push origin mdpiper/update-contributors
+```
+```
 Counting objects: 3, done.
 Delta compression using up to 16 threads.
 Compressing objects: 100% (3/3), done.
@@ -410,6 +432,8 @@ First,
 use the `git remote` subcommand to view what remotes are being tracked by your local repository:
 ```
 git remote -v
+```
+```
 origin	git@github.com:mdpiper/ivy-collaboration.git (fetch)
 origin	git@github.com:mdpiper/ivy-collaboration.git (push)
 ```
@@ -424,6 +448,8 @@ git remote add upstream git@github.com:csdms/ivy-collaboration.git
 Check the result with another call to `git remote`:
 ```
 git remote -v
+```
+```
 origin	git@github.com:mdpiper/ivy-collaboration.git (fetch)
 origin	git@github.com:mdpiper/ivy-collaboration.git (push)
 upstream	git@github.com:csdms/ivy-collaboration.git (fetch)
@@ -434,6 +460,8 @@ Next, switch back to the *main* branch in your local repository.
 This is the branch into which the pull request was merged.
 ```
 git checkout main
+```
+```
 Switched to branch 'main'
 Your branch is up-to-date with 'origin/main'.
 ```

--- a/lessons/git/github-authentication.md
+++ b/lessons/git/github-authentication.md
@@ -24,7 +24,7 @@ Before we create a new SSH key,
 let's check if you already have one on your system.
 Open a terminal and type
 ```
-$ ls ~/.ssh
+ls ~/.ssh
 ```
 
 GitHub supports three types of keys.
@@ -45,7 +45,7 @@ proceed to the next section.
 To create a new SSH key,
 type the following into a terminal:
 ```
-$ ssh-keygen -t ed25519 -C "YOUR EMAIL"
+ssh-keygen -t ed25519 -C "YOUR EMAIL"
 ```
 The `-t` flag specifies the type of key to create;
 in this case,
@@ -56,7 +56,7 @@ Follow the prompts and enter a passphrase for the key.
 
 Check the contents of your **.ssh** directory (which will now exist if it didn't before):
 ```
-$ ls ~/.ssh
+ls ~/.ssh
 id_ed25519      id_ed25519.pub
 ```
 You now have an SSH key pair (private, public).
@@ -75,7 +75,7 @@ we need to add the public key to GitHub.
 Start by copying the public key.
 Print the key to the terminal with `cat`:
 ```
-$ cat ~/.ssh/id_ed25519.pub
+cat ~/.ssh/id_ed25519.pub
 ssh-ed25519 AA4WC3NzqC45ZD81NTR5AQAAIBbFO9USDsVFLRIiBJ9Y6wJil4AFrW5ysRrGNCd5wDvy mark.piper@colorado.edu
 ```
 then select the text and copy it.
@@ -96,7 +96,7 @@ That's it!
 
 To check that GitHub has your SSH key, type the following in a terminal:
 ```
-$ ssh -T git@github.com
+ssh -T git@github.com
 ```
 You'll be prompted to enter the passphrase for your key.
 

--- a/lessons/git/github-authentication.md
+++ b/lessons/git/github-authentication.md
@@ -57,6 +57,8 @@ Follow the prompts and enter a passphrase for the key.
 Check the contents of your **.ssh** directory (which will now exist if it didn't before):
 ```
 ls ~/.ssh
+```
+```
 id_ed25519      id_ed25519.pub
 ```
 You now have an SSH key pair (private, public).
@@ -76,6 +78,8 @@ Start by copying the public key.
 Print the key to the terminal with `cat`:
 ```
 cat ~/.ssh/id_ed25519.pub
+```
+```
 ssh-ed25519 AA4WC3NzqC45ZD81NTR5AQAAIBbFO9USDsVFLRIiBJ9Y6wJil4AFrW5ysRrGNCd5wDvy mark.piper@colorado.edu
 ```
 then select the text and copy it.


### PR DESCRIPTION
I've removed the `$` prompt from the *bash* commands in the *git* lessons. This allows students to click the copy button to get the command, which they can then paste directly into their shell. Before, they were pasting the command along with the `$`, which caused errors.