### PR TITLE
Fix broken link to image

### DIFF
--- a/lessons/python/oop.ipynb
+++ b/lessons/python/oop.ipynb
@@ -49,8 +49,8 @@
     "## Concepts\n",
     "\n",
     "<figure style=\"float: right;\">\n",
-    "    <a href=\"https://en.wikipedia.org/wiki/File:Left_side_of_Flying_Pigeon.jpg\"><img src=\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/41/Left_side_of_Flying_Pigeon.jpg/320px-Left_side_of_Flying_Pigeon.jpg\" alt=\"A Flying Pigeon bicycle.\"/></a>\n",
-    "    <figcaption><i>Figure 1: A Flying Pigeon bicycle.</i></figcaption>\n",
+    "    <a href=\"https://en.wikipedia.org/wiki/File:Left_side_of_Flying_Pigeon.jpg\"><img src=\"https://upload.wikimedia.org/wikipedia/commons/thumb/4/41/Left_side_of_Flying_Pigeon.jpg/330px-Left_side_of_Flying_Pigeon.jpg\" alt=\"A Flying Pigeon bicycle. (source: Wikipedia)\"/></a>\n",
+    "    <figcaption><i>Figure 1: A Flying Pigeon bicycle. (source: Wikipedia)</i></figcaption>\n",
     "</figure>\n",
     "\n",
     "Let's explore some OOP concepts through bicycles.\n",
@@ -670,7 +670,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.9"
+   "version": "3.13.11"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This PR fixes a broken link to the Wikipedia image for a Flying Pigeon bicycle in the OOP lesson. I also added an attribution to Wikipedia in the caption.